### PR TITLE
Combine es. into one token in ad es.

### DIFF
--- a/it_isdt-ud-dev.conllu
+++ b/it_isdt-ud-dev.conllu
@@ -4181,7 +4181,7 @@
 # text = così ad es., nell'acquisto e nella rivendita di valori azionari, come pure nel traffico dei beni immobiliari e in altre speculazioni del genere in modo che attualmente disporrebbe di un cospicuo patrimonio, ma, per le sue origini, di assai dubbia provenienza.
 1	così	così	ADV	B	_	3	advmod	3:advmod	_
 2	ad	a	ADP	E	_	3	case	3:case	_
-3	es.	es.	NOUN	S	_	7	nmod	7:nmod:a	SpaceAfter=No
+3	es.	esempio	NOUN	S	_	7	nmod	7:nmod:a	SpaceAfter=No
 4	,	,	PUNCT	FF	_	3	punct	3:punct	_
 5-6	nell'	_	_	_	_	_	_	_	SpaceAfter=No
 5	in	in	ADP	E	_	7	case	7:case	_
@@ -10723,32 +10723,31 @@
 31	diritto	diritto	NOUN	S	Gender=Masc|Number=Sing	27	nmod	27:nmod:su	_
 32	d'	di	ADP	E	_	33	case	33:case	SpaceAfter=No
 33	autore	autore	NOUN	S	Gender=Masc|Number=Sing	31	nmod	31:nmod:di	_
-34	(	(	PUNCT	FB	_	40	punct	40:punct	SpaceAfter=No
+34	(	(	PUNCT	FB	_	39	punct	39:punct	SpaceAfter=No
 35	ad	a	ADP	E	_	36	case	36:case	_
-36	es	es	NOUN	S	_	40	nmod	40:nmod:a	SpaceAfter=No
-37	.	.	PUNCT	FF	_	36	punct	36:punct	_
-38	per	per	ADP	E	_	40	case	40:case	_
-39	l'	il	DET	RD	Definite=Def|Number=Sing|PronType=Art	40	det	40:det	SpaceAfter=No
-40	inserimento	inserimento	NOUN	S	Gender=Masc|Number=Sing	27	nmod	27:nmod:per	_
-41-42	dell'	_	_	_	_	_	_	_	SpaceAfter=No
-41	di	di	ADP	E	_	43	case	43:case	_
-42	l'	il	DET	RD	Definite=Def|Number=Sing|PronType=Art	43	det	43:det	_
-43	opera	opera	NOUN	S	Gender=Fem|Number=Sing	40	nmod	40:nmod:di	_
-44	in	in	ADP	E	_	46	case	46:case	_
-45	un'	uno	DET	RI	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	46	det	46:det	SpaceAfter=No
-46	antologia	antologia	NOUN	S	Gender=Fem|Number=Sing	40	nmod	40:nmod:in	_
-47	ad	a	ADP	E	_	48	case	48:case	_
-48	uso	uso	NOUN	S	Gender=Masc|Number=Sing	46	nmod	46:nmod:a	_
-49	scolastico	scolastico	ADJ	A	Gender=Masc|Number=Sing	48	amod	48:amod	_
-50	ex	ex	ADJ	A	_	51	amod	51:amod	_
-51	art.	articolo	NOUN	S	Gender=Masc|Number=Sing	40	nmod	40:nmod	_
-52	70	70	NUM	N	NumType=Card	51	nummod	51:nummod	_
-53	l.	legge	NOUN	S	Gender=Fem|Number=Sing	51	nmod	51:nmod	_
-54	633	633	NUM	N	NumType=Card	53	nummod	53:nummod	SpaceAfter=No
-55	/	/	PUNCT	FF	_	54	punct	54:punct	SpaceAfter=No
-56	1941	1941	NUM	N	NumType=Card	54	compound	54:compound	SpaceAfter=No
-57	)	)	PUNCT	FB	_	40	punct	40:punct	SpaceAfter=No
-58	.	.	PUNCT	FS	_	9	punct	9:punct	_
+36	es.	esempio	NOUN	S	_	39	nmod	39:nmod:a	_
+37	per	per	ADP	E	_	39	case	39:case	_
+38	l'	il	DET	RD	Definite=Def|Number=Sing|PronType=Art	39	det	39:det	SpaceAfter=No
+39	inserimento	inserimento	NOUN	S	Gender=Masc|Number=Sing	27	nmod	27:nmod:per	_
+40-41	dell'	_	_	_	_	_	_	_	SpaceAfter=No
+40	di	di	ADP	E	_	42	case	42:case	_
+41	l'	il	DET	RD	Definite=Def|Number=Sing|PronType=Art	42	det	42:det	_
+42	opera	opera	NOUN	S	Gender=Fem|Number=Sing	39	nmod	39:nmod:di	_
+43	in	in	ADP	E	_	45	case	45:case	_
+44	un'	uno	DET	RI	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	45	det	45:det	SpaceAfter=No
+45	antologia	antologia	NOUN	S	Gender=Fem|Number=Sing	39	nmod	39:nmod:in	_
+46	ad	a	ADP	E	_	47	case	47:case	_
+47	uso	uso	NOUN	S	Gender=Masc|Number=Sing	45	nmod	45:nmod:a	_
+48	scolastico	scolastico	ADJ	A	Gender=Masc|Number=Sing	47	amod	47:amod	_
+49	ex	ex	ADJ	A	_	50	amod	50:amod	_
+50	art.	articolo	NOUN	S	Gender=Masc|Number=Sing	39	nmod	39:nmod	_
+51	70	70	NUM	N	NumType=Card	50	nummod	50:nummod	_
+52	l.	legge	NOUN	S	Gender=Fem|Number=Sing	50	nmod	50:nmod	_
+53	633	633	NUM	N	NumType=Card	52	nummod	52:nummod	SpaceAfter=No
+54	/	/	PUNCT	FF	_	53	punct	53:punct	SpaceAfter=No
+55	1941	1941	NUM	N	NumType=Card	53	compound	53:compound	SpaceAfter=No
+56	)	)	PUNCT	FB	_	39	punct	39:punct	SpaceAfter=No
+57	.	.	PUNCT	FS	_	9	punct	9:punct	_
 
 # sent_id = 1_CC-74
 # text = Nessuna clausola di questa licenza esclude o limita la responsabilità nel caso in cui questa dipenda da dolo o colpa grave.


### PR DESCRIPTION
There are a few cases where `es.` was split into multiple tokens, despite it being an abbreviation.  I combined them into one word in this changelist.  I also set the lemma as `esempio`, as the standard in this treebank is generally to use the full version of an abbreviation for the lemma.